### PR TITLE
Fix duplicate key issue in recipe

### DIFF
--- a/.azure-pipelines/azure-pipelines-linux.yml
+++ b/.azure-pipelines/azure-pipelines-linux.yml
@@ -12,7 +12,6 @@ jobs:
         CONFIG: linux_64_
         UPLOAD_PACKAGES: 'True'
         DOCKER_IMAGE: condaforge/linux-anvil-comp7
-    maxParallel: 8
   timeoutInMinutes: 360
 
   steps:

--- a/.scripts/run_docker_build.sh
+++ b/.scripts/run_docker_build.sh
@@ -74,6 +74,8 @@ docker run ${DOCKER_RUN_ARGS} \
            -e CI \
            -e FEEDSTOCK_NAME \
            -e CPU_COUNT \
+           -e BUILD_WITH_CONDA_DEBUG \
+           -e BUILD_OUTPUT_ID \
            -e BINSTAR_TOKEN \
            -e FEEDSTOCK_TOKEN \
            -e STAGING_BINSTAR_TOKEN \

--- a/README.md
+++ b/README.md
@@ -5,9 +5,13 @@ Home: http://github.com/QuantStack/ipysheet
 
 Package license: BSD-3-Clause
 
-Feedstock license: BSD-3-Clause
+Feedstock license: [BSD-3-Clause](https://github.com/conda-forge/ipysheet-feedstock/blob/master/LICENSE.txt)
 
 Summary: Spreadsheet widget for Jupyter
+
+Development: https://github.com/QuantStack/ipysheet
+
+Documentation: https://ipysheet.readthedocs.io/en/latest/
 
 Spreadsheet widget for Jupyter
 

--- a/build-locally.py
+++ b/build-locally.py
@@ -12,6 +12,10 @@ from argparse import ArgumentParser
 def setup_environment(ns):
     os.environ["CONFIG"] = ns.config
     os.environ["UPLOAD_PACKAGES"] = "False"
+    if ns.debug:
+        os.environ["BUILD_WITH_CONDA_DEBUG"] = "1"
+        if ns.output_id:
+            os.environ["BUILD_OUTPUT_ID"] = ns.output_id
 
 
 def run_docker_build(ns):
@@ -51,6 +55,14 @@ def verify_config(ns):
 def main(args=None):
     p = ArgumentParser("build-locally")
     p.add_argument("config", default=None, nargs="?")
+    p.add_argument(
+        "--debug",
+        action="store_true",
+        help="Setup debug environment using `conda debug`",
+    )
+    p.add_argument(
+        "--output-id", help="If running debug, specify the output to setup."
+    )
 
     ns = p.parse_args(args=args)
     verify_config(ns)

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -10,7 +10,7 @@ source:
   sha256: 54e9dffb4384db8586d3ca6be6fd5679157f6cf98ecc9ad368fa938f889e58b2
 
 build:
-  number: 0
+  number: 1
   noarch: python
   script: "{{ PYTHON }} -m pip install . --no-deps -vv"
 
@@ -36,7 +36,7 @@ about:
   summary: 'Spreadsheet widget for Jupyter'
   description: 'Spreadsheet widget for Jupyter'
   dev_url: https://github.com/QuantStack/ipysheet
-  dev_url: https://github.com/QuantStack/ipysheet
+  doc_url: https://ipysheet.readthedocs.io/en/latest/
 
 extra:
   recipe-maintainers:


### PR DESCRIPTION
Add a link to the documentation instead.
Duplicate keys prevent the automatic version update detection bot
from running.

<!--
Thank you for pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number (if the version is unchanged)
* [x] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [x] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
